### PR TITLE
Hotfix/openssl

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -46,6 +46,7 @@ RUN set -xe; \
         ca-certificates \
         cmake \
         cron \
+        debconf \
         fcgiwrap \
         findutils \
         git \
@@ -71,6 +72,7 @@ RUN set -xe; \
         libmcrypt4 \
         libpam-runtime \
         libpng16-16 \
+        libssl1.1 \
         libxml2 \
         libyaml-0-2 \
         libzip4 \
@@ -78,9 +80,9 @@ RUN set -xe; \
         make \
         mariadb-client \
         nano \
-        openssl \
         openssh-server \
         openssh-client \
+        openssl \
         patch \
         pkg-config \
         rsync \

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -43,7 +43,6 @@ RUN set -xe; \
         apt-transport-https \
         autoconf \
         bzip2 \
-        ca-certificates \
         cmake \
         cron \
         fcgiwrap \
@@ -71,7 +70,6 @@ RUN set -xe; \
         libmcrypt4 \
         libpam-runtime \
         libpng16-16 \
-        libssl1.1 \
         libxml2 \
         libyaml-0-2 \
         libzip4 \
@@ -94,6 +92,7 @@ RUN set -xe; \
         uw-mailutils \
         wget; \
     \
+
     # Debian dev packages needed.
     apt-get update; \
     apt-get install -y --no-install-recommends \
@@ -114,12 +113,12 @@ RUN set -xe; \
         librabbitmq-dev \
         librdkafka-dev \
         libtidy-dev \
-        uuid-dev \
         libwebp-dev \
         libxml2-dev \
         libxslt1-dev \
         libyaml-dev \
-        libzip-dev; \
+        libzip-dev \
+        uuid-dev; \
     \
     docker-php-source extract; \
     \

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -46,7 +46,6 @@ RUN set -xe; \
         ca-certificates \
         cmake \
         cron \
-        debconf \
         fcgiwrap \
         findutils \
         git \

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -78,6 +78,7 @@ RUN set -xe; \
         make \
         mariadb-client \
         nano \
+        openssl \
         openssh-server \
         openssh-client \
         patch \


### PR DESCRIPTION
Package ca-certificates needs openssl >= 1.1.1 but apt-get install version 1.1.0. We removed ca-certificates because probably is unnecessary.